### PR TITLE
Mutli Platform Images: build arm64 images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,9 @@ jobs:
           go-version: 1.21
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Install docker-compose
-        run: sudo apt-get install -y docker-compose
+        with:
+          platforms: linux/amd64,linux/arm64
+          install: true
       - name: Build
         run: go run build.go
         env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,8 +18,9 @@ jobs:
           go-version: 1.21
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Install docker-compose
-        run: sudo apt-get install -y docker-compose
+        with:
+          platforms: linux/amd64,linux/arm64
+          install: true
       - name: Build & Push
         run: go run build.go --push
         env:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the scripts that build the ContainerSSH container image
 
 This repository contains a build script in Go called `build.go`. It can be invoked by running `go run build.go`. This script will read [build.yaml](build.yaml) and build the container image based on that revision. It uses the GitHub API to download release artifacts, so it may need the `GITHUB_TOKEN` environment variable set. The optional `--push` flag can be set to push the images to the corresponding registries.
 
-Under the hood the build uses [`docker-compose`](https://docs.docker.com/compose/) to build, test, and push the images. The build steps can be performed manually.
+Under the hood the build uses [`docker compose`](https://docs.docker.com/compose/) to build, test, and push the images. The build steps can be performed manually.
 
 Before you begin you must set several environment variables. These are the following:
 
@@ -26,15 +26,15 @@ Before you begin you must set several environment variables. These are the follo
 For example, on Linux/MacOS:
 
 ```bash
-CONTAINERSSH_VERSION="0.3.1"
-CONTAINERSSH_TAG="0.3.1"
+CONTAINERSSH_VERSION="v0.5.2"
+CONTAINERSSH_TAG="v0.5.2"
 ```
 
 On Windows/PowerShell:
 
 ```ps1
-$env:CONTAINERSSH_VERSION="0.3.1"
-$env:CONTAINERSSH_TAG="0.3.1"
+$env:CONTAINERSSH_VERSION="v0.5.2"
+$env:CONTAINERSSH_TAG="v0.5.2"
 ```
 
 ### Build
@@ -44,7 +44,7 @@ The build step requires build arguments to function. At the very least it should
 Optionally, you can also specify a `GITHUB_TOKEN` to work around GitHub rate limits and `SOURCE_REPO` to point the build to a different source URL.
 
 ```bash
-docker-compose build
+docker compose build
 ``` 
 
 ### Test
@@ -52,21 +52,21 @@ docker-compose build
 Testing is done via a container called `sut`. This container will wait for ContainerSSH to come up and then run a simple SSH connection to it to test that it works correctly. This is not a comprehensive test, but checks if the image build was successful.
 
 ```
-docker-compose up --abort-on-container-exit --exit-code-from=sut
+docker compose up --abort-on-container-exit --exit-code-from=sut
 ```
 
 ### Clean up after test
 
 ```
-docker-compose down
+docker compose down
 ```
 
 ### Push
 
-Finally, pushing container images can also be done from `docker-compose`. After a `docker login` command this can be simply done using the following command:
+Finally, pushing container images can also be done from `docker compose`. After a `docker login` command this can be simply done using the following command:
 
 ```
-docker-compose push
+docker compose push
 ```
 
 ## Versioning

--- a/build.yaml
+++ b/build.yaml
@@ -8,16 +8,6 @@ versions:
     - v0.5.1
   v0.5.0:
     - v0.5.0
-  v0.5.0-alpha.1:
-    - 0.5.0-alpha.1
-  v0.4.1:
-    - 0.4.1
-    - 0.4
-  v0.4.0:
-    - 0.4.0
-  0.3.1:
-    - 0.3.1
-    - 0.3
 registries:
   docker.io:
     user_variable: DOCKER_USERNAME

--- a/containerssh-test-authconfig/Dockerfile
+++ b/containerssh-test-authconfig/Dockerfile
@@ -6,6 +6,8 @@ FROM alpine AS download
 ARG CONTAINERSSH_VERSION
 ARG GITHUB_TOKEN
 ARG SOURCE_REPO
+ARG TARGETOS
+ARG TARGETARCH
 RUN if [ -z "${CONTAINERSSH_VERSION}" ]; then echo "Error: No CONTAINERSSH_VERSION specified." >&2; exit 1; fi
 RUN if [ -z "${GITHUB_TOKEN}" ]; then echo "Warning: No GITHUB_TOKEN specified, build may fail." >&2; fi
 RUN apk add --no-cache curl
@@ -17,9 +19,9 @@ RUN mkdir -p /containerssh && \
 USER 1022:1022
 RUN cd /containerssh && \
     if [ "${CONTAINERSSH_VERSION}" = "0.3.0" -o "${CONTAINERSSH_VERSION}" = "0.3.1" ]; then \
-        URL=${SOURCE_REPO}/releases/download/${CONTAINERSSH_VERSION}/containerssh-authconfig_${CONTAINERSSH_VERSION}_linux_amd64.tar.gz; \
+        URL=${SOURCE_REPO}/releases/download/${CONTAINERSSH_VERSION}/containerssh-authconfig_${CONTAINERSSH_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz; \
     else \
-        URL=${SOURCE_REPO}/releases/download/${CONTAINERSSH_VERSION}/containerssh_${CONTAINERSSH_VERSION/v/}_linux_amd64.tar.gz; \
+        URL=${SOURCE_REPO}/releases/download/${CONTAINERSSH_VERSION}/containerssh_${CONTAINERSSH_VERSION/v/}_${TARGETOS}_${TARGETARCH}.tar.gz; \
     fi && \
     if [ -n "${CONTAINERSSH_VERSION}" ]; then \
         curl -L -o containerssh-authconfig.tar.gz --header 'authorization: Bearer ${GITHUB_TOKEN}' ${URL}; \

--- a/containerssh/Dockerfile
+++ b/containerssh/Dockerfile
@@ -6,6 +6,8 @@ FROM alpine AS download
 ARG CONTAINERSSH_VERSION
 ARG GITHUB_TOKEN
 ARG SOURCE_REPO
+ARG TARGETOS
+ARG TARGETARCH
 RUN if [ -z "${CONTAINERSSH_VERSION}" ]; then echo "Error: No CONTAINERSSH_VERSION specified." >&2; exit 1; fi
 RUN if [ -z "${GITHUB_TOKEN}" ]; then echo "Warning: No GITHUB_TOKEN specified, build may fail." >&2; fi
 RUN apk add --no-cache curl
@@ -16,7 +18,7 @@ RUN mkdir -p /containerssh && \
 # Drop privileges for download
 USER 1022:1022
 RUN cd /containerssh && \
-    URL=${SOURCE_REPO}/releases/download/${CONTAINERSSH_VERSION}/containerssh_${CONTAINERSSH_VERSION/v/}_linux_amd64.tar.gz && \
+    URL=${SOURCE_REPO}/releases/download/${CONTAINERSSH_VERSION}/containerssh_${CONTAINERSSH_VERSION/v/}_${TARGETOS}_${TARGETARCH}.tar.gz && \
     if [ -n "${GITHUB_TOKEN}" ]; then \
         curl -L -o containerssh.tar.gz --header 'authorization: Bearer ${GITHUB_TOKEN}' ${URL}; \
     else \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,12 @@
 ---
-version: '3.9'
 services:
   containerssh:
     image: ${REGISTRY:-}containerssh/containerssh:${CONTAINERSSH_TAG:?CONTAINERSSH_TAG variable must be set}
     build:
       context: containerssh
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
       args:
         CONTAINERSSH_VERSION: ${CONTAINERSSH_VERSION:?CONTAINERSSH_VERSION variable must be set.}
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
@@ -29,6 +31,9 @@ services:
     image: ${REGISTRY:-}containerssh/containerssh-test-authconfig:${CONTAINERSSH_TAG:?CONTAINERSSH_TAG variable must be set}
     build:
       context: containerssh-test-authconfig
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
       args:
         CONTAINERSSH_VERSION: ${CONTAINERSSH_VERSION:?CONTAINERSSH_VERSION variable must be set.}
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}


### PR DESCRIPTION
**Name:** Multi Platform Images
**About:** switched build workflow to multi platform images

## Intention:
I'm running a k8s cluster with arm64 only nodes. As the containerSSH images previously were amd64 only I wasn't able to run it on those nodes. As there are already arm64 binaries building arm64 images is also possible.

## Changes

### Improvements to Docker and Docker Compose:
* `.github/workflows/push.yml` and `.github/workflows/tag.yml`: Updated the Docker Buildx setup to include multi-platform support for `linux/amd64` and `linux/arm64`. "docker-compose" install isn't needed anymore as buildx contains "docker compose" [[1]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L22-R24) [[2]](diffhunk://#diff-84dff8d1094ca39c02ac0e48d951ca22f4da29c76b50ae517f5bd2d50f94c2f6L21-R23)
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L2-R9): Added platform specifications for `linux/amd64` and `linux/arm64` to the build contexts for `containerssh` and `containerssh-test-authconfig` services. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L2-R9) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R34-R36)

### Updates to `build.go` script:
* Replaced `docker-compose` commands with `docker compose` as docker-compose is legacy and not included in standard buildx installations anymore. [[1]](diffhunk://#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L103-R122) [[2]](diffhunk://#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L119-R144) [[3]](diffhunk://#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L142-R168) [[4]](diffhunk://#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L162-R182) [[5]](diffhunk://#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L203-R235) [[6]](diffhunk://#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L223-R281)
* Introduced a new optional `OrganisationVariable` field in the `registry` struct to support organization-specific image naming. This is especially usefull when testing the build with a private registry where the organizational name isn't equal to the username username.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14): Updated references from `docker-compose` to `docker compose` and revised example environment variable values. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R37) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R69)

### Other changes:
* [`build.yaml`](diffhunk://#diff-2f7f69286606c0ff1642fac8ecb40ee91874b65bb544af172e32552c91a44799L11-L20): Dropped build of versions which don't have arm64 binaries
* `containerssh-test-authconfig/Dockerfile` and `containerssh/Dockerfile`: Added `TARGETOS` and `TARGETARCH` arguments to support multi-platform builds. [[1]](diffhunk://#diff-52c3540f8d7dfc3bbf8039e8b2311a38922a3a62b320decf2c9c65787d7696e1R9-R10) [[2]](diffhunk://#diff-52c3540f8d7dfc3bbf8039e8b2311a38922a3a62b320decf2c9c65787d7696e1L20-R24) [[3]](diffhunk://#diff-1c23fb8ee63dc0d12a0fba5abf3d0e8a430849e93642755cc6305ee1ce40b507R9-R10) [[4]](diffhunk://#diff-1c23fb8ee63dc0d12a0fba5abf3d0e8a430849e93642755cc6305ee1ce40b507L19-R21)


## Organisational
**Are you the owner of the code or do you have permission of the owner?**
Yes

**The code will be published under the MIT-0 license. Have you read and understood this license?**
Yes



